### PR TITLE
Quick enum class

### DIFF
--- a/src/main/java/edu/rosehulman/covidtracer/model/Role.java
+++ b/src/main/java/edu/rosehulman/covidtracer/model/Role.java
@@ -34,7 +34,7 @@ public class Role implements Serializable {
 }
 
 enum ROLE {
-	PERSON, HEALTH_SERVICES, CONTACT_TRACER, HEAD_CONTACT_TRACER, STUDENT_AFFAIRS;
+	PERSON, HEALTH_SERVICES, CONTACT_TRACER, HEAD_CONTACT_TRACER, STUDENT_AFFAIRS, SYSTEM_ADMIN;
 
 	public String toString(){
 		switch(this){
@@ -48,6 +48,8 @@ enum ROLE {
 				return "Head Contact Tracer";
 			case STUDENT_AFFAIRS:
 				return "Student Affairs";
+			case SYSTEM_ADMIN:
+				return "System Admin";
 			default:
 				return "Role Unspecified";
 		}
@@ -63,6 +65,8 @@ enum ROLE {
 				return ROLE.HEAD_CONTACT_TRACER;
 			case "student affairs":
 				return ROLE.STUDENT_AFFAIRS;
+			case "system admin":
+				return ROLE.SYSTEM_ADMIN;
 			default:
 				return ROLE.PERSON;
 		}

--- a/src/main/java/edu/rosehulman/covidtracer/model/Role.java
+++ b/src/main/java/edu/rosehulman/covidtracer/model/Role.java
@@ -15,13 +15,12 @@ public class Role implements Serializable {
 	private Long ID;
 
 	@Column(name = "Role", nullable = false, unique = true)
-	private String role;
+	private ROLE role;
 
-	public Role() {
-	}
+	public Role() {}
 
 	public Role(String role) {
-		this.role = role;
+		this.role = ROLE.roleFromString(role);
 	}
 
 	public Long getID() {
@@ -29,7 +28,43 @@ public class Role implements Serializable {
 	}
 
 	public String getRole() {
-		return role;
+		return role.toString();
 	}
 
+}
+
+enum ROLE {
+	PERSON, HEALTH_SERVICES, CONTACT_TRACER, HEAD_CONTACT_TRACER, STUDENT_AFFAIRS;
+
+	public String toString(){
+		switch(this){
+			case PERSON:
+				return "Person";
+			case HEALTH_SERVICES:
+				return "Health Services";
+			case CONTACT_TRACER:
+				return "Contact Tracer";
+			case HEAD_CONTACT_TRACER:
+				return "Head Contact Tracer";
+			case STUDENT_AFFAIRS:
+				return "Student Affairs";
+			default:
+				return "Role Unspecified";
+		}
+	}
+
+	public static ROLE roleFromString(String role){
+		switch(role){
+			case "health services":
+				return ROLE.HEALTH_SERVICES;
+			case "contact tracer":
+				return ROLE.CONTACT_TRACER;
+			case "head contact tracer":
+				return ROLE.HEAD_CONTACT_TRACER;
+			case "student affairs":
+				return ROLE.STUDENT_AFFAIRS;
+			default:
+				return ROLE.PERSON;
+		}
+	}
 }


### PR DESCRIPTION
Closes #35 

Quick enum that describes roles. Changed a couple of phrasings from Trello board to try and keep a single style convention, all describe the user (as opposed to the action)

